### PR TITLE
Run multiple soffice instances safely

### DIFF
--- a/converter/converter.go
+++ b/converter/converter.go
@@ -129,11 +129,16 @@ func (converter) Supported(filename string) bool {
 
 func (converter) Convert(ctx context.Context, filePath string) (convertedPath string, err error) {
 	dir := filepath.Dir(filePath)
+	profDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
 	err = well.CommandContext(ctx,
 		libreOffice,
 		"--headless",
 		"--convert-to", "pdf",
 		"--outdir", dir,
+		"-env:UserInstallation=file://"+profDir,
 		filePath).Run()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
To run multiple `soffice` instances, each instance needs a dedicated profile directory.

ref: https://ask.libreoffice.org/en/question/82515/how-can-i-run-multiple-instances-of-soffice-under-linux/